### PR TITLE
Remove drop table statuses due to error

### DIFF
--- a/db/migrate/20140711044454_create_statuses.rb
+++ b/db/migrate/20140711044454_create_statuses.rb
@@ -1,6 +1,5 @@
 class CreateStatuses < ActiveRecord::Migration
   def change
-    drop_table :statuses
     create_table :statuses do |t|
       t.text :body
       t.integer :dog_id


### PR DESCRIPTION
This PR removes the `drop_table :statuses` line from the migration because it would cause an error when running `rake db:migrate` with a fresh db.